### PR TITLE
Filter Atom's Ignored Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Open recent files in the current window, and recent folders (optionally) in a ne
 * `replaceNewWindowOnOpenDirectory` When true, opening a recent directory will "open" in the current window, but only if the window does not have a project path set. Eg: The window that appears when doing File > New Window.
 * `replaceProjectOnOpenDirectory` When true, opening a recent directory will "open" in the current window, replacing the current project.
 * `listDirectoriesAddedToProject` When true, the all root directories in a project will be added to the history and not just the 1st root directory.
+* `ignoredNames` When true, skips files and directories specified in Atom's "Ignored Names" setting.

--- a/package.json
+++ b/package.json
@@ -10,5 +10,7 @@
   "engines": {
     "atom": ">0.148.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "minimatch": "^2.0.9"
+  }
 }


### PR DESCRIPTION
Adds a setting to let Open Recent filter its list based on the ignored names in Atom's core config. This keeps files and paths containing .git out.

![screenshot 2015-10-29 23 22 14](https://cloud.githubusercontent.com/assets/6807/10837806/06813684-7e94-11e5-9c22-bac2da9dd7d7.png)
